### PR TITLE
Add query random order

### DIFF
--- a/FlowAnal/database/query_database.py
+++ b/FlowAnal/database/query_database.py
@@ -9,6 +9,7 @@ from sqlalchemy import and_
 from sqlalchemy.sql import func
 from sqlalchemy.orm import aliased
 from sqlalchemy.dialects import sqlite
+import random
 
 from FlowAnal.utils import Vividict
 from FlowAnal.database.FCS_declarative import *
@@ -91,7 +92,7 @@ class queryDB(object):
         self.q.joined_tables = ['TubeCases', 'TubeTypesInstances']
 
         # Add common filters
-        self.__add_filters_to_query(**kwargs)
+        self.__add_mods_to_query(**kwargs)
 
         log.debug('Query:')
         log.debug(self.q.statement)
@@ -104,7 +105,7 @@ class queryDB(object):
                     files[x.case_number][x.tube_type][x.date] = path.join(x.dirname, x.filename)
             except:
                 self.session.rollback()
-                raise "Failed to query TubeCases"
+                raise Exception("Failed to query TubeCases")
             return files
         elif exporttype == 'df':
             df = self.__q2df()
@@ -138,7 +139,7 @@ class queryDB(object):
         self.q.joined_tables = ['TubeCases']
 
         # Add common filters
-        self.__add_filters_to_query(**kwargs)
+        self.__add_mods_to_query(**kwargs)
 
         log.debug('Query:')
         log.debug(self.q.statement)
@@ -179,7 +180,7 @@ class queryDB(object):
                                 func.max(func.datetime(TubeCases.date)).label("last_dttm")).\
             group_by(TubeCases.case_number)
         q1.joined_tables = ['TubeCases']
-        q1 = add_filters_to_query(q1, **kwargs)
+        q1 = add_mods_to_query(q1, **kwargs)
         q1 = q1.subquery()
 
         self.q = self.session.query(TubeCases.case_number,
@@ -190,7 +191,7 @@ class queryDB(object):
         self.q.joined_tables = ['TubeCases']
 
         # Add common filters
-        self.__add_filters_to_query(**kwargs)
+        self.__add_mods_to_query(**kwargs)
         log.debug("\nQuery:\n{}\n".format(self.q.statement))
 
         # Output
@@ -202,7 +203,7 @@ class queryDB(object):
         """ Return list of cases """
         self.q = self.session.query(Cases.case_number)
         self.q.joined_tables = ['Cases']
-        self.__add_filters_to_query(**kwargs)
+        self.__add_mods_to_query(**kwargs)
         d = self.q.all()
 
         if aslist is False:
@@ -233,7 +234,7 @@ class queryDB(object):
         # keep track of explicitly joined tables
         self.q.joined_tables = ['TubeCases', 'PmtTubeCases', 'PmtStats', 'TubeStats']
 
-        self.__add_filters_to_query(**kwargs)
+        self.__add_mods_to_query(**kwargs)
         df = self.__q2df()
 
         return df
@@ -262,7 +263,7 @@ class queryDB(object):
         self.q.joined_tables = ['TubeCases', 'TubeStats',
                                 'TubeTypesInstances']
 
-        self.__add_filters_to_query(**kwargs)
+        self.__add_mods_to_query(**kwargs)
 
         df = self.__q2df()
         return df
@@ -291,7 +292,7 @@ class queryDB(object):
         self.q.joined_tables = ['TubeCases', 'Cases',
                                 'CustomCaseData']
 
-        self.__add_filters_to_query(**kwargs)
+        self.__add_mods_to_query(**kwargs)
 
         df = self.__q2df()
         return df
@@ -319,7 +320,7 @@ class queryDB(object):
                      PmtHistos.bin)
 
         self.q.joined_tables = ['TubeCases', 'PmtHistos', 'PmtTubeCases']
-        self.__add_filters_to_query(**kwargs)
+        self.__add_mods_to_query(**kwargs)
 
         df = self.__q2df()
         return df
@@ -348,7 +349,7 @@ class queryDB(object):
 
         self.q.joined_tables = ['TubeCases', 'PmtTubeCases', 'PmtTubeCasesIN', 'PmtCompCorr']
 
-        self.__add_filters_to_query(**kwargs)
+        self.__add_mods_to_query(**kwargs)
 
         df = self.__q2df()
         return df
@@ -430,14 +431,14 @@ class queryDB(object):
 
         self.session.commit()
 
-    def __add_filters_to_query(self, **kwargs):
+    def __add_mods_to_query(self, **kwargs):
         """ Add filters specified in kwargs to q
 
         Keyword arguments:
         tubes -- <list> Select set based on tube types
         daterange -- <list> [X,X] Select set based on date between daterange
         """
-        self.q = add_filters_to_query(self.q, **kwargs)
+        self.q = add_mods_to_query(self.q, **kwargs)
 
     def compile_query(self):
         statement = self.q.statement.compile(dialect=sqlite.dialect())
@@ -452,8 +453,14 @@ class queryDB(object):
                                params=params)
         return df
 
+    def query_random_index(self):
+        """ Return randomized index for query Q """
+        x = range(0, self.q.count())
+        random.shuffle(x)
+        return x
 
-def add_filters_to_query(q, **kwargs):
+
+def add_mods_to_query(q, **kwargs):
     if 'not_flagged' in kwargs and kwargs['not_flagged'] is True:
         q = q.filter(TubeCases.flag == 'GOOD')
         if 'TubeCases' not in q.joined_tables:
@@ -505,5 +512,11 @@ def add_filters_to_query(q, **kwargs):
 
     if 'custom_set' in kwargs and kwargs['custom_set'] is not None:
         q = q.join(CustomCaseData)
+
+    if 'random_order' in kwargs and kwargs['random_order'] is True:
+        q = q.order_by(func.random())
+
+    if 'record_n' in kwargs and kwargs['record_n'] is not None:
+        q = q.limit(kwargs['record_n'])
 
     return q

--- a/FlowAnal/database/query_database.py
+++ b/FlowAnal/database/query_database.py
@@ -9,7 +9,6 @@ from sqlalchemy import and_
 from sqlalchemy.sql import func
 from sqlalchemy.orm import aliased
 from sqlalchemy.dialects import sqlite
-import random
 
 from FlowAnal.utils import Vividict
 from FlowAnal.database.FCS_declarative import *
@@ -452,12 +451,6 @@ class queryDB(object):
                                con=self.db.engine,
                                params=params)
         return df
-
-    def query_random_index(self):
-        """ Return randomized index for query Q """
-        x = range(0, self.q.count())
-        random.shuffle(x)
-        return x
 
 
 def add_mods_to_query(q, **kwargs):

--- a/FlowAnal/subcommands/__init__.py
+++ b/FlowAnal/subcommands/__init__.py
@@ -36,4 +36,15 @@ def add_filter_args(parser):
                         help='List of case_tube_idxs to select',
                         nargs='+', action='store',
                         default=None, type=str)
+    parser.add_argument('-rand', '--random-order',
+                        dest='random_order',
+                        help='Return database results in random order',
+                        default=False,
+                        action='store_true')
+    parser.add_argument('--limit', '--record-n',
+                        dest='record_n',
+                        help='Number of records for database to return',
+                        default=None, type=int)
+
+
 

--- a/FlowAnal/utils.py
+++ b/FlowAnal/utils.py
@@ -5,6 +5,7 @@ import bz2
 import gzip
 import shutil
 import sys
+from collections import OrderedDict
 
 log = logging.getLogger(__name__)
 
@@ -79,7 +80,7 @@ def opener(pth, mode='r', bufsize=-1):
     return Opener(mode, bufsize)(pth)
 
 
-class Vividict(dict):
+class Vividict(OrderedDict):
     """ Class to enable creation of dict objects with missing data \
     This allows dynamic addition of chains of dictionaries
     """


### PR DESCRIPTION
Added subcommand flags that get passed to database queries and effect Number of records return and Randomization of orders.

**init**.py
    parser.add_argument('-rand', '--random-order',
                        dest='random_order',
                        help='Return database results in random order',
                        default=False,
                        action='store_true')
    parser.add_argument('--limit', '--record-n',
                        dest='record_n',
                        help='Number of records for database to return',
                        default=None, type=int)

Please test out, try for testing singlet_gating, merge master.
Thanks
